### PR TITLE
Registering component types at runtime

### DIFF
--- a/src/ECS/Archetype/EntityStore.cs
+++ b/src/ECS/Archetype/EntityStore.cs
@@ -120,7 +120,8 @@ public abstract partial class EntityStoreBase
     {
         internal static readonly    EntitySchema    EntitySchema    = SchemaUtils.RegisterSchemaTypes();
         /// <summary>All items in the <see cref="DefaultHeapMap"/> are always null</summary>
-        internal static readonly    StructHeap[]    DefaultHeapMap  = new StructHeap[EntitySchema.maxStructIndex];
+        internal static             StructHeap[]    DefaultHeapMap  = new StructHeap[EntitySchema.InitialCapacity];
+        private  static readonly    object          HeapMapLock     = new();
         
         /// <summary>The index of the <see cref="EntityStoreBase.defaultArchetype"/> - index is always 0</summary>
         internal const              int             DefaultArchIndex        =  0;
@@ -135,6 +136,22 @@ public abstract partial class EntityStoreBase
     //  internal const              int             StoreRootParentId       = -1;
     
         internal const              int             SingleMax               = 32;
+        
+        /// <summary>
+        /// Resizes the DefaultHeapMap when new component types are registered at runtime.
+        /// </summary>
+        internal static void ResizeDefaultHeapMap(int newCapacity)
+        {
+            lock (HeapMapLock)
+            {
+                if (newCapacity <= DefaultHeapMap.Length)
+                    return;
+                    
+                var newHeapMap = new StructHeap[newCapacity];
+                Array.Copy(DefaultHeapMap, newHeapMap, DefaultHeapMap.Length);
+                DefaultHeapMap = newHeapMap;
+            }
+        }
     }
     #endregion
     

--- a/src/ECS/Base/EntitySchema.cs
+++ b/src/ECS/Base/EntitySchema.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Friflo.Engine.ECS.Index;
+using Friflo.Engine.ECS.Relations;
 using static System.Diagnostics.DebuggerBrowsableState;
 using Browse = System.Diagnostics.DebuggerBrowsableAttribute;
 
@@ -26,19 +29,19 @@ public sealed class EntitySchema
     /// <see cref="ComponentType.StructIndex"/> is equal to the array index<br/>
     /// <see cref="Components"/>[0] is always null
     /// </remarks>
-    public   ReadOnlySpan<ComponentType>                Components          => new (components);
+    public   ReadOnlySpan<ComponentType>                Components          => new (components, 0, maxStructIndex);
     /// <summary> Return all <see cref="Script"/> types - classes extending <see cref="Script"/></summary>
     /// <remarks>
     /// <see cref="ScriptType.ScriptIndex"/> is equal to the array index<br/>
     /// <see cref="Scripts"/>[0] is always null
     /// </remarks>
-    public   ReadOnlySpan<ScriptType>                   Scripts             => new (scripts);
+    public   ReadOnlySpan<ScriptType>                   Scripts             => new (scripts, 0, maxScriptIndex);
     /// <summary> Return all <b>Tag</b> types - structs implementing <see cref="ITag"/>. </summary>
     /// <remarks>
     /// <see cref="TagType.TagIndex"/> is equal to the array index<br/>
     /// <see cref="Tags"/>[0] is always null
     /// </remarks>
-    public   ReadOnlySpan<TagType>                      Tags                => new (tags);
+    public   ReadOnlySpan<TagType>                      Tags                => new (tags, 0, maxTagIndex);
     
     // --- lookup: components / scripts
     /// <summary> A map to lookup <see cref="ComponentType"/>'s and <see cref="ScriptType"/>'s by <see cref="SchemaType.ComponentKey"/>. </summary>
@@ -66,12 +69,14 @@ public sealed class EntitySchema
     #endregion
     
 #region private fields
-    [Browse(Never)] private  readonly   EngineDependant[]                   engineDependants;
-    [Browse(Never)] internal readonly   int                                 maxStructIndex;
-    [Browse(Never)] internal readonly   int                                 maxIndexedStructIndex; // :)
-    [Browse(Never)] internal readonly   ComponentType[]                     components;
-    [Browse(Never)] internal readonly   ScriptType[]                        scripts;
-    [Browse(Never)] internal readonly   TagType[]                           tags;
+    [Browse(Never)] private             EngineDependant[]                   engineDependants;
+    [Browse(Never)] internal            int                                 maxStructIndex;
+    [Browse(Never)] internal            int                                 maxIndexedStructIndex; // :)
+    [Browse(Never)] internal            int                                 maxScriptIndex;
+    [Browse(Never)] internal            int                                 maxTagIndex;
+    [Browse(Never)] internal            ComponentType[]                     components;
+    [Browse(Never)] internal            ScriptType[]                        scripts;
+    [Browse(Never)] internal            TagType[]                           tags;
     [Browse(Never)] internal readonly   ComponentType                       unresolvedType;
     // --- lookup: component / script
     [Browse(Never)] internal readonly   Dictionary<string, SchemaType>      schemaTypeByKey;
@@ -81,11 +86,14 @@ public sealed class EntitySchema
     [Browse(Never)] internal readonly   Dictionary<string, TagType>         tagTypeByName;
     [Browse(Never)] private  readonly   Dictionary<Type,   TagType>         tagTypeByType;
     // --- component type masks
-    [Browse(Never)] internal readonly   ComponentTypes                      componentTypes;
-    [Browse(Never)] internal readonly   ComponentTypes                      relationTypes;
-    [Browse(Never)] internal readonly   ComponentTypes                      indexTypes;
-    [Browse(Never)] internal readonly   ComponentTypes                      linkComponentTypes;
-    [Browse(Never)] internal readonly   ComponentTypes                      linkRelationTypes;
+    [Browse(Never)] internal            ComponentTypes                      componentTypes;
+    [Browse(Never)] internal            ComponentTypes                      relationTypes;
+    [Browse(Never)] internal            ComponentTypes                      indexTypes;
+    [Browse(Never)] internal            ComponentTypes                      linkComponentTypes;
+    [Browse(Never)] internal            ComponentTypes                      linkRelationTypes;
+    // --- for dynamic registration
+    [Browse(Never)] private  readonly   object                              schemaLock = new();
+    [Browse(Never)] internal const      int                                 InitialCapacity = 256; // Pre-allocate space for dynamic types
     #endregion
     
 #region internal methods
@@ -103,10 +111,18 @@ public sealed class EntitySchema
         componentTypeByType     = new Dictionary<Type,   ComponentType>();
         tagTypeByName           = new Dictionary<string, TagType>   (count);
         tagTypeByType           = new Dictionary<Type,   TagType>   (count);
+        
+        // Use larger initial capacity to support dynamic registration
+        var componentCapacity   = Math.Max(componentList.Count + 1, InitialCapacity);
+        var scriptCapacity      = Math.Max(scriptList.Count + 1, InitialCapacity);
+        var tagCapacity         = Math.Max(tagList.Count + 1, InitialCapacity);
+        
         maxStructIndex          = componentList.Count + 1;
-        components              = new ComponentType[maxStructIndex];
-        scripts                 = new ScriptType[scriptList.Count + 1];
-        tags                    = new TagType   [tagList.Count + 1];
+        maxScriptIndex          = scriptList.Count + 1;
+        maxTagIndex             = tagList.Count + 1;
+        components              = new ComponentType[componentCapacity];
+        scripts                 = new ScriptType[scriptCapacity];
+        tags                    = new TagType[tagCapacity];
 
         // --- Solved workaround. But leave it here for record. SHOULD_USE_ADD
         // Commented methods should use Dictionary<,>.Add()
@@ -122,6 +138,7 @@ public sealed class EntitySchema
             }
             componentTypeByType.Add (componentType.Type,            componentType);
             components              [componentType.StructIndex] =   componentType;
+            RuntimeTypeRegistry.MarkTypeRegistered(componentType.Type);
             if (componentType.RelationType == null) {
                 componentTypes.Add(new ComponentTypes(componentType));
             } else {
@@ -146,6 +163,7 @@ public sealed class EntitySchema
             } 
             scriptTypeByType.Add    (scriptType.Type,               scriptType);
             scripts                 [scriptType.ScriptIndex] =      scriptType;
+            RuntimeTypeRegistry.MarkTypeRegistered(scriptType.Type);
         }
         foreach (var tagType in tagList) {
             var name = tagType.TagName;
@@ -154,6 +172,7 @@ public sealed class EntitySchema
             }
             tagTypeByType.Add       (tagType.Type,                  tagType);
             tags                    [tagType.TagIndex] =            tagType;
+            RuntimeTypeRegistry.MarkTypeRegistered(tagType.Type);
         }
         CreateNameSortIndexes();
     }
@@ -168,6 +187,175 @@ public sealed class EntitySchema
     {
         var msg = $"warning: Duplicate tag name: '{tagType.TagName}' for: {tagType.Type.FullName}. Add unique [TagName()] attribute.";
         Console.WriteLine(msg);
+    }
+    
+    /// <summary>
+    /// Adds a type to the schema at runtime. Called by <see cref="RuntimeTypeRegistry"/> when registering
+    /// types after the schema has been created.
+    /// </summary>
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070", Justification = "Dynamic registration uses reflection")]
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL3050", Justification = "Dynamic registration uses reflection")]
+    internal void AddTypeRuntime(Type type, SchemaTypeKind kind)
+    {
+        lock (schemaLock)
+        {
+            switch (kind)
+            {
+                case SchemaTypeKind.Component:
+                    if (componentTypeByType.ContainsKey(type))
+                        return; // Already registered
+                    AddComponentTypeRuntime(type);
+                    break;
+                case SchemaTypeKind.Tag:
+                    if (tagTypeByType.ContainsKey(type))
+                        return; // Already registered
+                    AddTagTypeRuntime(type);
+                    break;
+                case SchemaTypeKind.Script:
+                    if (scriptTypeByType.ContainsKey(type))
+                        return; // Already registered
+                    AddScriptTypeRuntime(type);
+                    break;
+            }
+        }
+    }
+    
+    private const BindingFlags Flags = BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.InvokeMethod;
+    
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070", Justification = "Dynamic registration uses reflection")]
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL3050", Justification = "Dynamic registration uses reflection")]
+    private void AddComponentTypeRuntime(Type type)
+    {
+        var structIndex = maxStructIndex;
+        
+        // Ensure array capacity
+        if (structIndex >= components.Length)
+        {
+            var newCapacity = components.Length * 2;
+            var newComponents = new ComponentType[newCapacity];
+            Array.Copy(components, newComponents, components.Length);
+            components = newComponents;
+            
+            // Update the static DefaultHeapMap as well
+            EntityStoreBase.Static.ResizeDefaultHeapMap(newCapacity);
+        }
+        
+        // Determine if this is a relation type
+        var relationType = RelationTypeUtils.GetEntityRelationsType(type, out Type keyType);
+        var indexType = ComponentIndexUtils.GetIndexType(type, out var indexValueType);
+        
+        ComponentType componentType;
+        if (relationType != null)
+        {
+            // It's a relation type
+            var createParams = new object[] { structIndex, relationType, keyType };
+            var method = typeof(SchemaUtils).GetMethod(nameof(SchemaUtils.CreateRelationType), Flags);
+            var genericMethod = method!.MakeGenericMethod(type);
+            componentType = (ComponentType)genericMethod.Invoke(null, createParams);
+        }
+        else
+        {
+            // Regular component
+            var createParams = new object[] { structIndex, indexType, indexValueType };
+            var method = typeof(SchemaUtils).GetMethod(nameof(SchemaUtils.CreateComponentType), Flags);
+            var genericMethod = method!.MakeGenericMethod(type);
+            componentType = (ComponentType)genericMethod.Invoke(null, createParams);
+        }
+        
+        // Add to schema
+        var key = componentType.ComponentKey;
+        if (key != null)
+        {
+            if (!schemaTypeByKey.TryAdd(key, componentType))
+            {
+                DuplicateComponentKey(componentType);
+            }
+        }
+        componentTypeByType.Add(componentType.Type, componentType);
+        components[structIndex] = componentType;
+        maxStructIndex++;
+        
+        // Update component type masks
+        if (componentType.RelationType == null)
+        {
+            componentTypes.Add(new ComponentTypes(componentType));
+        }
+        else
+        {
+            relationTypes.Add(new ComponentTypes(componentType));
+            if (componentType.RelationKeyType == typeof(Entity))
+            {
+                linkRelationTypes.Add(new ComponentTypes(componentType));
+            }
+        }
+        if (componentType.IndexType != null)
+        {
+            indexTypes.Add(new ComponentTypes(componentType));
+            if (componentType.IndexValueType == typeof(Entity))
+            {
+                linkComponentTypes.Add(new ComponentTypes(componentType));
+            }
+        }
+    }
+    
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070", Justification = "Dynamic registration uses reflection")]
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL3050", Justification = "Dynamic registration uses reflection")]
+    private void AddTagTypeRuntime(Type type)
+    {
+        var tagIndex = maxTagIndex;
+        
+        // Ensure array capacity
+        if (tagIndex >= tags.Length)
+        {
+            var newCapacity = tags.Length * 2;
+            var newTags = new TagType[newCapacity];
+            Array.Copy(tags, newTags, tags.Length);
+            tags = newTags;
+        }
+        
+        var createParams = new object[] { tagIndex };
+        var method = typeof(SchemaUtils).GetMethod(nameof(SchemaUtils.CreateTagType), Flags);
+        var genericMethod = method!.MakeGenericMethod(type);
+        var tagType = (TagType)genericMethod.Invoke(null, createParams);
+        
+        var name = tagType.TagName;
+        if (!tagTypeByName.TryAdd(name, tagType))
+        {
+            DuplicateTagName(tagType);
+        }
+        tagTypeByType.Add(tagType.Type, tagType);
+        tags[tagIndex] = tagType;
+        maxTagIndex++;
+    }
+    
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070", Justification = "Dynamic registration uses reflection")]
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL3050", Justification = "Dynamic registration uses reflection")]
+    private void AddScriptTypeRuntime(Type type)
+    {
+        var scriptIndex = maxScriptIndex;
+        
+        // Ensure array capacity
+        if (scriptIndex >= scripts.Length)
+        {
+            var newCapacity = scripts.Length * 2;
+            var newScripts = new ScriptType[newCapacity];
+            Array.Copy(scripts, newScripts, scripts.Length);
+            scripts = newScripts;
+        }
+        
+        var createParams = new object[] { scriptIndex };
+        var method = typeof(SchemaUtils).GetMethod(nameof(SchemaUtils.CreateScriptType), Flags);
+        var genericMethod = method!.MakeGenericMethod(type);
+        var scriptType = (ScriptType)genericMethod.Invoke(null, createParams);
+        
+        var key = scriptType.ComponentKey;
+        if (!schemaTypeByKey.TryAdd(key, scriptType))
+        {
+            DuplicateComponentKey(scriptType);
+        }
+        scriptTypeByType.Add(scriptType.Type, scriptType);
+        scripts[scriptIndex] = scriptType;
+        maxScriptIndex++;
     }
     
     /// <summary>
@@ -221,15 +409,15 @@ public sealed class EntitySchema
     }
     
     private string GetString() {
-        return $"components: {components.Length - 1}  scripts: {scripts.Length - 1}  entity tags: {tags.Length - 1}";
+        return $"components: {maxStructIndex - 1}  scripts: {maxScriptIndex - 1}  entity tags: {maxTagIndex - 1}";
     }
     
     private void CreateNameSortIndexes()
     {
         // --- ComponentType
         var componentArray  = components;
-        var entries         = new SortIndexEntry[componentArray.Length - 1];
-        for (int i = 1; i < componentArray.Length; i++) {
+        var entries         = new SortIndexEntry[maxStructIndex - 1];
+        for (int i = 1; i < maxStructIndex; i++) {
             entries[i - 1] = new SortIndexEntry { index = i, name = componentArray[i].Name };
         }
         Array.Sort(entries);
@@ -238,8 +426,8 @@ public sealed class EntitySchema
         }
         // --- TagType
         var tagsArray   = tags;
-        entries         = new SortIndexEntry[tagsArray.Length - 1];
-        for (int i = 1; i < tagsArray.Length; i++) {
+        entries         = new SortIndexEntry[maxTagIndex - 1];
+        for (int i = 1; i < maxTagIndex; i++) {
             entries[i - 1] = new SortIndexEntry { index = i, name = tagsArray[i].Name };
         }
         Array.Sort(entries);

--- a/src/ECS/Base/RuntimeTypeRegistry.cs
+++ b/src/ECS/Base/RuntimeTypeRegistry.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+// ReSharper disable once CheckNamespace
+namespace Friflo.Engine.ECS;
+
+/// <summary>
+/// Provides methods to register <see cref="IComponent"/>, <see cref="ITag"/>, and <see cref="Script"/> types at runtime.<br/>
+/// <br/>
+/// Types can be registered either before or after an <see cref="EntityStore"/> is created.
+/// When registering after the schema is created, the new types will be added dynamically.
+/// </summary>
+/// <remarks>
+/// Usage example:
+/// <code>
+/// // Register types - can be done at any time
+/// RuntimeTypeRegistry.RegisterType(typeof(MyComponent));
+/// RuntimeTypeRegistry.RegisterType(typeof(MyTag));
+/// 
+/// // Create or use EntityStore
+/// var store = new EntityStore();
+/// 
+/// // Can also register more types after EntityStore is created
+/// RuntimeTypeRegistry.RegisterType(typeof(AnotherComponent));
+/// </code>
+/// </remarks>
+public static class RuntimeTypeRegistry
+{
+    private static readonly object                  LockObject      = new();
+    private static readonly List<AssemblyType>      PendingTypes    = new();
+    private static readonly HashSet<Type>           TypeSet         = new();
+    private static          bool                    SchemaCreated;
+    
+    /// <summary>
+    /// Register a type implementing <see cref="IComponent"/>, <see cref="ITag"/>, or extending <see cref="Script"/>
+    /// for inclusion in the entity schema.<br/>
+    /// <br/>
+    /// Can be called at any time - before or after <see cref="EntityStore"/> creation.
+    /// </summary>
+    /// <param name="type">The type to register. Must implement IComponent, ITag, or extend Script.</param>
+    /// <exception cref="ArgumentNullException">Thrown if type is null.</exception>
+    /// <exception cref="ArgumentException">Thrown if type doesn't implement IComponent, ITag, or extend Script.</exception>
+    public static void RegisterType(Type type)
+    {
+        if (type == null)
+            throw new ArgumentNullException(nameof(type));
+        
+        var kind = GetSchemaTypeKind(type);
+        RegisterTypeInternal(type, kind);
+    }
+    
+    /// <summary>
+    /// Register a component type at runtime.
+    /// </summary>
+    /// <typeparam name="T">The component type implementing <see cref="IComponent"/>.</typeparam>
+    public static void RegisterComponent<T>() where T : struct, IComponent
+    {
+        RegisterTypeInternal(typeof(T), SchemaTypeKind.Component);
+    }
+    
+    /// <summary>
+    /// Register a tag type at runtime.
+    /// </summary>
+    /// <typeparam name="T">The tag type implementing <see cref="ITag"/>.</typeparam>
+    public static void RegisterTag<T>() where T : struct, ITag
+    {
+        RegisterTypeInternal(typeof(T), SchemaTypeKind.Tag);
+    }
+    
+    /// <summary>
+    /// Register a script type at runtime.
+    /// </summary>
+    /// <typeparam name="T">The script type extending <see cref="Script"/>.</typeparam>
+    public static void RegisterScript<T>() where T : Script, new()
+    {
+        RegisterTypeInternal(typeof(T), SchemaTypeKind.Script);
+    }
+    
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070", Justification = "Dynamic registration uses reflection")]
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL3050", Justification = "Dynamic registration uses reflection")]
+    private static void RegisterTypeInternal(Type type, SchemaTypeKind kind)
+    {
+        lock (LockObject)
+        {
+            if (!TypeSet.Add(type))
+                return; // Already registered
+            
+            if (SchemaCreated)
+            {
+                // Schema already exists - add type dynamically
+                var schema = EntityStoreBase.Static.EntitySchema;
+                schema.AddTypeRuntime(type, kind);
+            }
+            else
+            {
+                // Schema not yet created - add to pending list
+                var assembly = type.Assembly;
+                var assemblyType = new AssemblyType(type, kind, GetAssemblyIndex(assembly));
+                PendingTypes.Add(assemblyType);
+            }
+        }
+    }
+    
+    private static SchemaTypeKind GetSchemaTypeKind(Type type)
+    {
+        if (typeof(ITag).IsAssignableFrom(type))
+            return SchemaTypeKind.Tag;
+        
+        if (typeof(IComponent).IsAssignableFrom(type))
+            return SchemaTypeKind.Component;
+        
+        if (typeof(Script).IsAssignableFrom(type))
+            return SchemaTypeKind.Script;
+        
+        throw new ArgumentException(
+            $"Type '{type.FullName}' must implement IComponent, ITag, or extend Script.", 
+            nameof(type));
+    }
+    
+    private static readonly Dictionary<Assembly, int>   AssemblyMap     = new();
+    private static readonly List<Assembly>              AssemblyList    = new();
+    
+    private static int GetAssemblyIndex(Assembly assembly)
+    {
+        if (AssemblyMap.TryGetValue(assembly, out int index))
+            return index;
+        
+        // Use negative indices for runtime-registered assemblies
+        // These will be mapped properly when the schema is created
+        index = -AssemblyList.Count - 1;
+        AssemblyMap.Add(assembly, index);
+        AssemblyList.Add(assembly);
+        return index;
+    }
+    
+    /// <summary>
+    /// Gets all types registered via <see cref="RegisterType"/> before schema creation.
+    /// Called internally when creating the EntitySchema.
+    /// </summary>
+    internal static IReadOnlyList<AssemblyType> GetPendingTypes()
+    {
+        lock (LockObject)
+        {
+            return PendingTypes.ToArray();
+        }
+    }
+    
+    /// <summary>
+    /// Gets the assemblies that contain runtime-registered types.
+    /// </summary>
+    internal static IReadOnlyList<Assembly> GetRegisteredAssemblies()
+    {
+        lock (LockObject)
+        {
+            return AssemblyList.ToArray();
+        }
+    }
+    
+    /// <summary>
+    /// Marks the schema as created. After this point, new type registrations
+    /// will be added dynamically to the existing schema.
+    /// Called internally when the EntitySchema is created.
+    /// </summary>
+    internal static void MarkSchemaCreated()
+    {
+        lock (LockObject)
+        {
+            SchemaCreated = true;
+        }
+    }
+    
+    /// <summary>
+    /// Returns true if the schema has been created.
+    /// </summary>
+    internal static bool IsSchemaCreated
+    {
+        get
+        {
+            lock (LockObject)
+            {
+                return SchemaCreated;
+            }
+        }
+    }
+    
+    /// <summary>
+    /// Checks if a type has been registered (either pending or in the schema).
+    /// </summary>
+    internal static bool IsTypeRegistered(Type type)
+    {
+        lock (LockObject)
+        {
+            return TypeSet.Contains(type);
+        }
+    }
+    
+    /// <summary>
+    /// Marks a type as registered (called when schema adds a type from assembly scanning).
+    /// </summary>
+    internal static void MarkTypeRegistered(Type type)
+    {
+        lock (LockObject)
+        {
+            TypeSet.Add(type);
+        }
+    }
+    
+    /// <summary>
+    /// Resets the registry for testing purposes only.
+    /// </summary>
+    internal static void Reset()
+    {
+        lock (LockObject)
+        {
+            PendingTypes.Clear();
+            TypeSet.Clear();
+            AssemblyMap.Clear();
+            AssemblyList.Clear();
+            SchemaCreated = false;
+        }
+    }
+}


### PR DESCRIPTION
hi, I needed to add component types at runtime from a dynamically loaded assembly. This changes are low effort and vibe coded so i understand if you want to not bother to review. But i still want to explain the scenario why i needed this changes.
Imagine this scenario:
There is host.exe and plugin.dll. Host loads the plugin via an `AssemblyLoadContext` and retrieves the functions and types defined in that assembly. Plugin also defines structs that implements `IComponent`. The host wants to add/remove/update components of type defined in Plugin. Host does this through the functions in `EntityUtils` class:
```csharp
Type componentInPlugin = pluginAssembly.GetType("ComponentInPlugin");
EntitySchema entitySchema = EntityStore.GetEntitySchema();
ComponentType componentType = entitySchema.ComponentTypeByType[componentInPlugin];
EntityUtils.AddEntityComponent(entity, componentType);
```
This code crashes becasue `ComponentTypeByType` doesnt have the `componentInPlugin` type. Now the following works:
```csharp
Type componentInPlugin = pluginAssembly.GetType("ComponentInPlugin");
RuntimeTypeRegistry.RegisterType(componentInPlugin); // registers the type so that it can be used in ECS
EntitySchema entitySchema = EntityStore.GetEntitySchema();
ComponentType componentType = entitySchema.ComponentTypeByType[componentInPlugin];
EntityUtils.AddEntityComponent(entity, componentType);
```