### PR TITLE
fix IRelation deserialization adding phantom component (#114)

### DIFF
--- a/src/ECS/Serialize/ComponentReader.cs
+++ b/src/ECS/Serialize/ComponentReader.cs
@@ -274,6 +274,10 @@ internal sealed class ComponentReader
         for (int n = 0; n < count; n++)
         {
             ref var component   = ref components[n];
+            if (component.type == RawComponentType.Array) {
+                // case: relation
+                continue;
+            }
             var schemaType      = component.rawKey.schemaType;
             if (schemaType == unresolvedType) {
                 // case: unresolved component

--- a/src/Tests/ECS/Serialize/Test_SerializeRelations.cs
+++ b/src/Tests/ECS/Serialize/Test_SerializeRelations.cs
@@ -152,6 +152,110 @@ public static class Test_SerializeRelations
         AreEqual(Json, str);
     }
     #endregion
+
+
+#region round-trip relations
+    [Test]
+    public static void Test_SerializeRelations_roundtrip()
+    {
+        var store       = new EntityStore();
+        Entity entity1  = store.CreateEntity(1);
+        entity1.AddRelation(new IntRelation { value = 101 });
+
+        Entity entity2  = store.CreateEntity(2);
+        entity2.AddRelation(new IntRelation { value = 201 });
+        entity2.AddRelation(new IntRelation { value = 202 });
+
+        // --- write
+        var serializer  = new EntitySerializer();
+        using MemoryStream writeStream = new MemoryStream();
+        serializer.WriteStore(store, writeStream);
+
+        // --- read into new store
+        writeStream.Position = 0;
+        var target      = new EntityStore();
+        var result      = serializer.ReadIntoStore(target, writeStream);
+        IsNull(result.error);
+
+        // --- verify relations
+        var target1     = target.GetEntityById(1);
+        var relations1  = target1.GetRelations<IntRelation>();
+        AreEqual(1,     relations1.Length);
+        AreEqual(101,   relations1[0].value);
+
+        var target2     = target.GetEntityById(2);
+        var relations2  = target2.GetRelations<IntRelation>();
+        AreEqual(2,     relations2.Length);
+        AreEqual(201,   relations2[0].value);
+        AreEqual(202,   relations2[1].value);
+
+        // --- verify no phantom components added by deserialization
+        AreEqual(entity1.Archetype.ComponentCount, target1.Archetype.ComponentCount);
+        AreEqual(entity2.Archetype.ComponentCount, target2.Archetype.ComponentCount);
+    }
+
+    [Test]
+    public static void Test_SerializeRelations_roundtrip_with_components()
+    {
+        var store       = new EntityStore();
+        Entity entity1  = store.CreateEntity(1);
+        entity1.AddComponent(new EntityName("test"));
+        entity1.AddRelation(new IntRelation { value = 101 });
+
+        // --- write
+        var serializer  = new EntitySerializer();
+        using MemoryStream writeStream = new MemoryStream();
+        serializer.WriteStore(store, writeStream);
+
+        // --- read into new store
+        writeStream.Position = 0;
+        var target      = new EntityStore();
+        var result      = serializer.ReadIntoStore(target, writeStream);
+        IsNull(result.error);
+
+        // --- verify component and relation coexist without phantom
+        var target1     = target.GetEntityById(1);
+        AreEqual("test", target1.GetComponent<EntityName>().value);
+
+        var relations1  = target1.GetRelations<IntRelation>();
+        AreEqual(1,     relations1.Length);
+        AreEqual(101,   relations1[0].value);
+
+        AreEqual(entity1.Archetype.ComponentCount, target1.Archetype.ComponentCount);
+    }
+
+    [Test]
+    public static void Test_SerializeRelations_roundtrip_link_relation()
+    {
+        var store       = new EntityStore();
+        Entity entity1  = store.CreateEntity(1);
+        Entity entity2  = store.CreateEntity(2);
+        entity1.AddRelation(new AttackRelation { target = entity2, speed = 42 });
+
+        // --- write
+        var serializer  = new EntitySerializer();
+        using MemoryStream writeStream = new MemoryStream();
+        serializer.WriteStore(store, writeStream);
+
+        // --- read into new store
+        writeStream.Position = 0;
+        var target      = new EntityStore();
+        var result      = serializer.ReadIntoStore(target, writeStream);
+        IsNull(result.error);
+
+        // --- verify link relation preserved
+        var target1     = target.GetEntityById(1);
+        var relations1  = target1.GetRelations<AttackRelation>();
+        AreEqual(1,     relations1.Length);
+        AreEqual(2,     relations1[0].target.Id);
+        AreEqual(42,    relations1[0].speed);
+
+        var target2     = target.GetEntityById(2);
+        AreEqual(entity1.Archetype.ComponentCount, target1.Archetype.ComponentCount);
+        AreEqual(entity2.Archetype.ComponentCount, target2.Archetype.ComponentCount);
+    }
+
+    #endregion
 }
 
 }


### PR DESCRIPTION
Fixes #114

## Problem

`EntitySerializer.ReadIntoStore()` creates a phantom zero-initialized component when deserializing entities with `IRelation<T>` relations.

```csharp
var store = new EntityStore();
var entity = store.CreateEntity(1);
entity.AddRelation(new IntRelation { value = 101 });

var serializer = new EntitySerializer();
var stream = new MemoryStream();
serializer.WriteStore(store, stream);

stream.Position = 0;
var target = new EntityStore();
serializer.ReadIntoStore(target, stream);

// Before fix: target entity has phantom {"value":0} component + correct [{"value":101}] relation
// After fix:  target entity has only the correct relation
```

The relation data itself (`GetRelations<T>()`) is correct — the corruption is a phantom zero-initialized component in the archetype.

## Root Cause

`ReadComponents()` already distinguishes components from relations via `component.type` (line 111). `GetComponentTypes()` was the only path missing the same filter — `RawComponentType.Array` entries (relations) were included in the archetype `ComponentTypes` bitset because `RelationType<T>` inherits `ComponentType` with `SchemaTypeKind.Component`.

## Fix

Skip `RawComponentType.Array` entries in `GetComponentTypes()`, consistent with the existing pattern in `ReadComponents()`.

## Test

Added three round-trip tests (`WriteStore` → `ReadIntoStore`) to `Test_SerializeRelations`:
- `_roundtrip`: IRelation with single and multiple relations, verifies no phantom component
- `_roundtrip_with_components`: entity with both component and relation
- `_roundtrip_link_relation`: ILinkRelation round-trip (verifies no regression)

Happy to adjust the approach if you prefer a different fix direction.